### PR TITLE
Rename 1.0 to 1.x to clarify version requirement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-GraphLab Create 1.0 SDK (BETA)
+GraphLab Create 1.x SDK (BETA)
 ==============================
 
 The GraphLab Create SDK aims to provide 3rd party extensibility to GraphLab Create. The SDK provides:


### PR DESCRIPTION
We are referring to the SDK as "GraphLab Create 1.x SDK" elsewhere, to help eliminate confusion about GLC version requirement for extensions built with the SDK. The SDK is expected to work with all 1.x releases starting with 1.1 onward.
